### PR TITLE
Switching to asynchronous processing

### DIFF
--- a/ie_serving/config.py
+++ b/ie_serving/config.py
@@ -27,6 +27,6 @@ CPU_EXTENSION = os.environ.get('CPU_EXTENSION', default_cpu_extension)
 PLUGIN_DIR = os.environ.get('PLUGIN_DIR', None)
 LOGGING_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 LOG_PATH = os.getenv('LOG_PATH', None)
-
+INFERENCE_STATE_CHECK_INTERVAL = 0.001
 
 MAPPING_CONFIG_FILENAME = 'mapping_config.json'

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -142,8 +142,9 @@ def main():
                           help='model version policy',
                           required=False,
                           default='{"latest": { "num_versions":1 }}')
-    parser_b.add_argument('--num_workers', type=int, help='number of workers for parallel '
-                                                          'processing', required=False, default=1)
+    parser_b.add_argument('--num_workers', type=int,
+                          help='number of workers for parallel '
+                          'processing', required=False, default=1)
     parser_b.set_defaults(func=parse_one_model)
     args = parser.parse_args()
     logger.info("Log level set: {}".format(LOGGER_LVL))

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -123,6 +123,9 @@ def main():
                           required=True)
     parser_a.add_argument('--port', type=int, help='server port',
                           required=False, default=9000)
+    parser_a.add_argument('--num_workers', type=int,
+                          help='number of workers for parallel '
+                               'processing', required=False, default=1)
     parser_a.set_defaults(func=parse_config)
 
     parser_b = subparsers.add_parser('model',

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -106,7 +106,7 @@ def parse_one_model(args):
                      "Exception: {}".format(e))
         sys.exit()
     start_server(models={args.model_name: model},
-                 max_workers=1, port=args.port)
+                 max_workers=2, port=args.port)
 
 
 def main():

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -73,7 +73,8 @@ def parse_config(args):
                                        model_directory=config['config'][
                                            'base_path'],
                                        batch_size=batch_size,
-                                       model_version_policy=model_ver_policy)
+                                       model_version_policy=model_ver_policy,
+                                       num_workers=args.num_workers)
             models[config['config']['name']] = model
         except ValidationError as e_val:
             logger.warning("Model version policy for model {} is invalid. "
@@ -83,7 +84,7 @@ def parse_config(args):
             logger.warning("Unexpected error occurred in {} model. "
                            "Exception: {}".format(config['config']['name'],
                                                   e))
-    start_server(models=models, max_workers=1, port=args.port)
+    start_server(models=models, max_workers=args.num_workers, port=args.port)
 
 
 def parse_one_model(args):
@@ -92,7 +93,8 @@ def parse_one_model(args):
         model = ModelBuilder.build(model_name=args.model_name,
                                    model_directory=args.model_path,
                                    batch_size=args.batch_size,
-                                   model_version_policy=model_version_policy)
+                                   model_version_policy=model_version_policy,
+                                   num_workers=args.num_workers)
     except ValidationError as e_val:
         logger.error("Model version policy is invalid. "
                      "Exception: {}".format(e_val))
@@ -106,7 +108,7 @@ def parse_one_model(args):
                      "Exception: {}".format(e))
         sys.exit()
     start_server(models={args.model_name: model},
-                 max_workers=2, port=args.port)
+                 max_workers=args.num_workers, port=args.port)
 
 
 def main():
@@ -140,6 +142,8 @@ def main():
                           help='model version policy',
                           required=False,
                           default='{"latest": { "num_versions":1 }}')
+    parser_b.add_argument('--num_workers', type=int, help='number of worker for parallel '
+                                                          'processing', required=False, default=1)
     parser_b.set_defaults(func=parse_one_model)
     args = parser.parse_args()
     logger.info("Log level set: {}".format(LOGGER_LVL))

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -142,7 +142,7 @@ def main():
                           help='model version policy',
                           required=False,
                           default='{"latest": { "num_versions":1 }}')
-    parser_b.add_argument('--num_workers', type=int, help='number of worker for parallel '
+    parser_b.add_argument('--num_workers', type=int, help='number of workers for parallel '
                                                           'processing', required=False, default=1)
     parser_b.set_defaults(func=parse_one_model)
     args = parser.parse_args()

--- a/ie_serving/models/gs_model.py
+++ b/ie_serving/models/gs_model.py
@@ -109,14 +109,15 @@ class GSModel(Model):
             return None
 
     @classmethod
-    def get_engine_for_version(cls, version_attributes):
+    def get_engine_for_version(cls, version_attributes, num_workers):
         local_xml_file, local_bin_file, local_mapping_config = \
             cls.create_local_mirror(version_attributes)
         logger.info('Downloaded files from GCS')
         engine = IrEngine.build(model_xml=local_xml_file,
                                 model_bin=local_bin_file,
                                 mapping_config=local_mapping_config,
-                                batch_size=version_attributes['batch_size'])
+                                batch_size=version_attributes['batch_size'],
+                                num_workers=num_workers)
         cls.delete_local_mirror([local_xml_file, local_bin_file,
                                  local_mapping_config])
         logger.info('Deleted temporary files')

--- a/ie_serving/models/local_model.py
+++ b/ie_serving/models/local_model.py
@@ -51,10 +51,11 @@ class LocalModel(Model):
         return None
 
     @classmethod
-    def get_engine_for_version(cls, version_attributes):
+    def get_engine_for_version(cls, version_attributes, num_workers):
         engine = IrEngine.build(model_bin=version_attributes['bin_file'],
                                 model_xml=version_attributes['xml_file'],
                                 mapping_config=version_attributes
                                 ['mapping_config'],
-                                batch_size=version_attributes['batch_size'])
+                                batch_size=version_attributes['batch_size'],
+                                num_workers=num_workers)
         return engine

--- a/ie_serving/models/model.py
+++ b/ie_serving/models/model.py
@@ -42,7 +42,7 @@ class Model(ABC):
 
     @classmethod
     def build(cls, model_name: str, model_directory: str, batch_size,
-              model_version_policy: dict = None):
+              model_version_policy: dict = None, num_workers: int = 1):
         logger.info("Server start loading model: {}".format(model_name))
         versions_attributes = cls.get_versions_attributes(model_directory,
                                                           batch_size)
@@ -55,7 +55,7 @@ class Model(ABC):
         versions_attributes = [version for version in versions_attributes
                                if version['version_number']
                                in available_versions]
-        engines = cls.get_engines_for_model(versions_attributes)
+        engines = cls.get_engines_for_model(versions_attributes, num_workers)
         available_versions = [version_attributes['version_number'] for
                               version_attributes in versions_attributes]
         model = cls(model_name=model_name, model_directory=model_directory,
@@ -110,7 +110,7 @@ class Model(ABC):
                               "valid.".format(model_version_policy))
 
     @classmethod
-    def get_engines_for_model(cls, versions_attributes):
+    def get_engines_for_model(cls, versions_attributes, num_workers):
         inference_engines = {}
         failures = []
         for version_attributes in versions_attributes:
@@ -119,7 +119,7 @@ class Model(ABC):
                             "for version: {}".format(
                              version_attributes['version_number']))
                 inference_engines[version_attributes['version_number']] = \
-                    cls.get_engine_for_version(version_attributes)
+                    cls.get_engine_for_version(version_attributes, num_workers)
             except Exception as e:
                 logger.error("Error occurred while loading model "
                              "version: {}".format(version_attributes))
@@ -149,5 +149,5 @@ class Model(ABC):
 
     @classmethod
     @abstractmethod
-    def get_engine_for_version(cls, version_attributes):
+    def get_engine_for_version(cls, version_attributes, num_workers):
         pass

--- a/ie_serving/models/model_builder.py
+++ b/ie_serving/models/model_builder.py
@@ -23,14 +23,14 @@ from ie_serving.models.s3_model import S3Model
 class ModelBuilder:
     @staticmethod
     def build(model_name: str, model_directory: str,
-              model_version_policy: dict, batch_size):
+              model_version_policy: dict, batch_size, num_workers):
         parsed_path = urlparse(model_directory)
         if parsed_path.scheme == '':
             return LocalModel.build(model_name, model_directory, batch_size,
-                                    model_version_policy)
+                                    model_version_policy, num_workers)
         elif parsed_path.scheme == 'gs':
             return GSModel.build(model_name, model_directory, batch_size,
-                                 model_version_policy)
+                                 model_version_policy, num_workers)
         elif parsed_path.scheme == 's3':
             return S3Model.build(model_name, model_directory, batch_size,
-                                 model_version_policy)
+                                 model_version_policy, num_workers)

--- a/ie_serving/models/s3_model.py
+++ b/ie_serving/models/s3_model.py
@@ -110,14 +110,15 @@ class S3Model(Model):
             return None
 
     @classmethod
-    def get_engine_for_version(cls, version_attributes):
+    def get_engine_for_version(cls, version_attributes, num_workers):
         local_xml_file, local_bin_file, local_mapping_config = \
             cls.create_local_mirror(version_attributes)
         logger.info('Downloaded files from S3')
         engine = IrEngine.build(model_xml=local_xml_file,
                                 model_bin=local_bin_file,
                                 mapping_config=local_mapping_config,
-                                batch_size=version_attributes['batch_size'])
+                                batch_size=version_attributes['batch_size'],
+                                num_workers=num_workers)
         cls.delete_local_mirror([local_xml_file, local_bin_file,
                                  local_mapping_config])
         logger.info('Deleted temporary files')

--- a/ie_serving/server/service.py
+++ b/ie_serving/server/service.py
@@ -40,6 +40,8 @@ class PredictionServiceServicer(prediction_service_pb2.
         self.models = models
         self.inference_requests_queue = queue.Queue()
         [self.inference_requests_queue.put(ir_index) for ir_index in range(workers_number)]
+        self.predictions_count = 0
+        self.full_parallel_count = 0
 
     def Predict(self, request, context):
         """
@@ -76,14 +78,21 @@ class PredictionServiceServicer(prediction_service_pb2.
                          .format(code))
             return predict_pb2.PredictResponse()
 
+        self.predictions_count += 1
         inference_start_time = datetime.datetime.now()
 
         ir_index = self.inference_requests_queue.get()
+        if self.inference_requests_queue.empty():
+            self.full_parallel_count += 1
         inference_output = self.models[model_name].engines[version] \
-            .infer(inference_input, batch_size)
+            .infer(inference_input, ir_index)
         self.inference_requests_queue.put(ir_index)
 
         inference_end_time = datetime.datetime.now()
+
+        if self.predictions_count % 100 == 0:
+            logger.info((self.full_parallel_count/self.predictions_count) * 100)
+
         duration = (inference_end_time - inference_start_time)\
             .total_seconds() * 1000
         logger.debug("PREDICT; inference execution completed; {}; {}; {}ms"

--- a/ie_serving/server/start.py
+++ b/ie_serving/server/start.py
@@ -44,7 +44,7 @@ def serve(models, max_workers: int=1, port: int=9000):
                                   ('grpc.max_receive_message_length', GIGABYTE)
                                   ])
     prediction_service_pb2.add_PredictionServiceServicer_to_server(
-        PredictionServiceServicer(models=models), server)
+        PredictionServiceServicer(models=models, workers_number=max_workers), server)
     server.add_insecure_port('[::]:{}'.format(port))
     server.start()
     logger.info("Server listens on port {port} and will be "

--- a/ie_serving/server/start.py
+++ b/ie_serving/server/start.py
@@ -44,7 +44,8 @@ def serve(models, max_workers: int=1, port: int=9000):
                                   ('grpc.max_receive_message_length', GIGABYTE)
                                   ])
     prediction_service_pb2.add_PredictionServiceServicer_to_server(
-        PredictionServiceServicer(models=models, workers_number=max_workers), server)
+        PredictionServiceServicer(models=models, num_workers=max_workers),
+        server)
     server.add_insecure_port('[::]:{}'.format(port))
     server.start()
     logger.info("Server listens on port {port} and will be "

--- a/tests/functional/config.json
+++ b/tests/functional/config.json
@@ -4,7 +4,7 @@
       "config":{
         "name":"resnet_V1_50",
         "base_path":"/opt/ml/resnet_V1_50",
-        "batch_size":"auto"
+        "batch_size":"2"
       }
     },
     {

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -237,7 +237,7 @@ def start_server_single_model(request, get_image, get_test_dir,
                                                  'mode': 'ro'}}
     command = "/ie-serving-py/start_server.sh ie_serving model " \
               "--model_name resnet --model_path /opt/ml/resnet_V1_50 " \
-              "--port 9000"
+              "--port 9000 --num_workers 2"
 
     container = client.containers.run(image=get_image, detach=True,
                                       name='ie-serving-py-test-single',

--- a/tests/functional/test_batching.py
+++ b/tests/functional/test_batching.py
@@ -78,34 +78,6 @@ class TestBatchModelInference():
         print("output shape", output[out_name].shape)
         assert output[out_name].shape == (4, 1000), ERROR_SHAPE
 
-    def test_run_inference_auto(self, resnet_8_batch_model_downloader,
-                                input_data_downloader_v1_224,
-                                start_server_batch_model_auto,
-                                create_channel_for_batching_server_auto):
-
-        print("Downloaded model files:", resnet_8_batch_model_downloader)
-
-        # Connect to grpc service
-        stub = create_channel_for_batching_server_auto
-
-        batch_input = input_data_downloader_v1_224[:6, :, :, :]
-        out_name = 'resnet_v1_50/predictions/Reshape_1'
-        output = infer_batch(batch_input=batch_input, input_tensor='input',
-                             grpc_stub=stub, model_spec_name='resnet',
-                             model_spec_version=None,
-                             output_tensors=[out_name])
-        print("output shape", output[out_name].shape)
-        assert output[out_name].shape == (6, 1000), ERROR_SHAPE
-
-        batch_input = input_data_downloader_v1_224[:1, :, :, :]
-        out_name = 'resnet_v1_50/predictions/Reshape_1'
-        output = infer_batch(batch_input=batch_input, input_tensor='input',
-                             grpc_stub=stub, model_spec_name='resnet',
-                             model_spec_version=None,
-                             output_tensors=[out_name])
-        print("output shape", output[out_name].shape)
-        assert output[out_name].shape == (1, 1000), ERROR_SHAPE
-
     def test_get_model_metadata(self, resnet_8_batch_model_downloader,
                                 start_server_batch_model,
                                 create_channel_for_batching_server):

--- a/tests/functional/test_multi_models.py
+++ b/tests/functional/test_multi_models.py
@@ -131,9 +131,9 @@ class TestMuiltModelInference():
         model_name = 'resnet_V1_50'
         out_name = 'resnet_v1_50/predictions/Reshape_1'
         expected_input_metadata = {'input': {'dtype': 1,
-                                             'shape': [1, 3, 224, 224]}}
+                                             'shape': [2, 3, 224, 224]}}
         expected_output_metadata = {out_name: {'dtype': 1,
-                                               'shape': [1, 1000]}}
+                                               'shape': [2, 1000]}}
         request = get_model_metadata(model_name='resnet_V1_50')
         response = stub.GetModelMetadata(request, 10)
         input_metadata, output_metadata = model_metadata_response(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -83,7 +83,8 @@ def get_fake_ir_engine():
 @pytest.fixture
 def get_grpc_service_for_predict(get_fake_model):
     _real_time = grpc_testing.strict_real_time()
-    servicer = PredictionServiceServicer(models={'test': get_fake_model})
+    servicer = PredictionServiceServicer(models={'test': get_fake_model},
+                                         num_workers=1)
     descriptors_to_servicers = {
         PREDICT_SERVICE: servicer
     }

--- a/tests/unit/models/test_local_model.py
+++ b/tests/unit/models/test_local_model.py
@@ -51,7 +51,7 @@ def test_get_engines_for_model(mocker):
                            'mapping_config': 'mapping_config.json',
                            'version_number': 4, 'batch_size': None}]
     output = LocalModel.get_engines_for_model(
-        versions_attributes=available_versions)
+        versions_attributes=available_versions, num_workers=1)
     assert 2 == len(output)
     assert 'modelv2' == output[2]
     assert 'modelv4' == output[4]
@@ -74,7 +74,7 @@ def test_get_engines_for_model_with_ir_raises(mocker):
                            'mapping_config': 'mapping_config.json',
                            'version_number': 4, 'batch_size': None}]
     output = LocalModel.get_engines_for_model(
-        versions_attributes=available_versions)
+        versions_attributes=available_versions, num_workers=1)
     assert 2 == len(output)
     assert 'modelv2' == output[2]
     assert 'modelv4' == output[3]

--- a/tests/unit/models/test_model_builder.py
+++ b/tests/unit/models/test_model_builder.py
@@ -19,19 +19,19 @@ from ie_serving.models.model_builder import ModelBuilder
 def test_build_local_model(mocker):
     local_build_mocker = mocker.patch(
         'ie_serving.models.local_model.LocalModel.build')
-    ModelBuilder.build('model_name', 'opt/bucket/model', None, None)
+    ModelBuilder.build('model_name', 'opt/bucket/model', None, None, 1)
     assert local_build_mocker.called
 
 
 def test_build_gs_model(mocker):
     gs_build_mocker = mocker.patch(
         'ie_serving.models.gs_model.GSModel.build')
-    ModelBuilder.build('model_name', 'gs://bucket/model', None, None)
+    ModelBuilder.build('model_name', 'gs://bucket/model', None, None, 1)
     assert gs_build_mocker.called
 
 
 def test_build_s3_model(mocker):
     s3_build_mocker = mocker.patch(
         'ie_serving.models.s3_model.S3Model.build')
-    ModelBuilder.build('model_name', 's3://bucket/model', None, None)
+    ModelBuilder.build('model_name', 's3://bucket/model', None, None, 1)
     assert s3_build_mocker.called

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -71,8 +71,8 @@ def test_parse_one_model(mocker, should_fail, model_version_policy,
                          exceptions, unexpected_exception):
     args = collections.namedtuple('args',
                                   'model_name model_path batch_size'
-                                  ' model_version_policy port')
-    arguments = args('test', 'test', None, model_version_policy, 9000)
+                                  ' model_version_policy port num_workers')
+    arguments = args('test', 'test', None, model_version_policy, 9000, 1)
     if should_fail:
         if unexpected_exception:
             builder_mocker = mocker.patch('ie_serving.main.'


### PR DESCRIPTION
Changing from synchronous to asynchronous inference. Enabling processing with multiple workers for throughput oriented use cases. Employing [OpenVINO CPU Streams](https://software.intel.com/en-us/articles/OpenVINO-Inference-Engine-Optimization-Guide#cpu-streams).
New setting setting: 
number of gRPC server workers == number of [InferRequests](https://software.intel.com/en-us/articles/OpenVINO-InferEngine#inferrequest-class) for network == number of CPU Streams