### PR TITLE
Simplify Dockerfile and make more use of WORKDIR

### DIFF
--- a/Dockerfile_intelpython
+++ b/Dockerfile_intelpython
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
             vim \
             wget
 
+RUN pip install cython numpy
 ARG DLDT_DIR=/dldt-2018_R5
 RUN git clone --depth=1 -b 2018_R5 https://github.com/opencv/dldt.git ${DLDT_DIR} && \
     cd ${DLDT_DIR} && git submodule init && git submodule update --recursive && \
@@ -37,11 +38,11 @@ RUN git clone --depth=1 -b 2018_R5 https://github.com/opencv/dldt.git ${DLDT_DIR
 
 WORKDIR ${DLDT_DIR}
 RUN curl -L https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20180928.tgz | tar -xz
-WORKDIR ${DLDT_DIR}/inference-engine
-RUN mkdir build && cd build && cmake -DGEMM=MKL  -DMKLROOT=${DLDT_DIR}/mklml_lnx_2019.0.1.20180928 -DENABLE_MKL_DNN=ON  -DCMAKE_BUILD_TYPE=Release ..
-RUN cd build && make -j$(nproc)
-RUN pip install cython numpy && mkdir ie_bridges/python/build && cd ie_bridges/python/build && \
-    cmake -DInferenceEngine_DIR=${DLDT_DIR}/inference-engine/build -DPYTHON_EXECUTABLE=$(which python) -DPYTHON_LIBRARY=/opt/conda/lib/libpython3.6m.so -DPYTHON_INCLUDE_DIR=/opt/conda/include/python3.6m .. && \
+WORKDIR ${DLDT_DIR}/inference-engine/build
+RUN cmake -DGEMM=MKL  -DMKLROOT=${DLDT_DIR}/mklml_lnx_2019.0.1.20180928 -DENABLE_MKL_DNN=ON  -DCMAKE_BUILD_TYPE=Release ..
+RUN make -j$(nproc)
+WORKDIR ${DLDT_DIR}/inference-engine/ie_bridges/python/build
+RUN cmake -DInferenceEngine_DIR=${DLDT_DIR}/inference-engine/build -DPYTHON_EXECUTABLE=$(which python) -DPYTHON_LIBRARY=/opt/conda/lib/libpython3.6m.so -DPYTHON_INCLUDE_DIR=/opt/conda/include/python3.6m ${DLDT_DIR}/inference-engine/ie_bridges/python && \
     make -j$(nproc)
 
 FROM intelpython/intelpython3_core as PROD


### PR DESCRIPTION
Use WORKDIR's directory creation and get rid of some of the mkdir foo
&& cd foo stuff. Increase readbility and easier inspection when/if
compilation steps fail.

Fixes #32

Change-Id: I1904e891a0eb304be47580cb612ac5161e7a7eec
Signed-off-by: Joakim Roubert <joakimr@axis.com>