### PR TITLE
Dockerfiles: pipe curl downloads directly to tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ RUN git clone --depth=1 -b 2018_R5 https://github.com/opencv/dldt.git ${DLDT_DIR
     rm -Rf .git && rm -Rf model-optimizer
 
 WORKDIR ${DLDT_DIR}
-RUN curl -L -o ${DLDT_DIR}/mklml_lnx_2019.0.1.20180928.tgz https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20180928.tgz && \
-    tar -xzf ${DLDT_DIR}/mklml_lnx_2019.0.1.20180928.tgz && rm ${DLDT_DIR}/mklml_lnx_2019.0.1.20180928.tgz
+RUN curl -L https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20180928.tgz | tar -xz
 WORKDIR ${DLDT_DIR}/inference-engine
 RUN mkdir build && cd build && cmake -DGEMM=MKL  -DMKLROOT=${DLDT_DIR}/mklml_lnx_2019.0.1.20180928 -DENABLE_MKL_DNN=ON  -DCMAKE_BUILD_TYPE=Release ..
 RUN cd build && make -j4

--- a/Dockerfile_intelpython
+++ b/Dockerfile_intelpython
@@ -39,8 +39,7 @@ RUN git clone --depth=1 -b 2018_R5 https://github.com/opencv/dldt.git ${DLDT_DIR
     rm -Rf .git && rm -Rf model-optimizer
 
 WORKDIR ${DLDT_DIR}
-RUN curl -L -o ${DLDT_DIR}/mklml_lnx_2019.0.1.20180928.tgz https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20180928.tgz && \
-    tar -xzf ${DLDT_DIR}/mklml_lnx_2019.0.1.20180928.tgz && rm ${DLDT_DIR}/mklml_lnx_2019.0.1.20180928.tgz
+RUN curl -L https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20180928.tgz | tar -xz
 WORKDIR ${DLDT_DIR}/inference-engine
 RUN mkdir build && cd build && cmake -DGEMM=MKL  -DMKLROOT=${DLDT_DIR}/mklml_lnx_2019.0.1.20180928 -DENABLE_MKL_DNN=ON  -DCMAKE_BUILD_TYPE=Release ..
 RUN cd build && make -j4


### PR DESCRIPTION
Instead of saving to file, unpacking and then deleting file, we let
curl pipe its download directly to tar. Increased readbility and
maintainability.

Fixes #34

Change-Id: Ie9a70b9972589c626a2e2bf0139362e0d9d7de35
Signed-off-by: Joakim Roubert <joakimr@axis.com>