### PR TITLE
Use shell built-in case to determine toolkit version

### DIFF
--- a/Dockerfile_binary_openvino
+++ b/Dockerfile_binary_openvino
@@ -20,10 +20,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ADD l_openvino_toolkit*.tgz $TEMP_DIR/
 RUN cd $TEMP_DIR/l_openvino_toolkit* && \
     sed -i 's/decline/accept/g' silent.cfg && \
-    pwd | grep -q openvino_toolkit_p ; \
-    if [ $? = 0 ];then sed -i 's/COMPONENTS=DEFAULTS/COMPONENTS=;intel-openvino_base__noarch;intel-dldt_base__noarch;intel-setupvars__noarch;intel-inference_engine_sdk__noarch;intel-inference_engine_rt__noarch;intel-inference_engine_cpu__noarch;intel-inference_engine_vpu__noarch;intel-inference_engine_gna__noarch;intel-inference_engine_dlia__noarch;intel-openvino_base-pset/g' silent.cfg; fi && \
-    pwd | grep -q openvino_toolkit_fpga ; \
-    if [ $? = 0 ];then sed -i 's/COMPONENTS=DEFAULTS/COMPONENTS=;intel-ism__noarch;intel-cv-sdk-full-shared__noarch;intel-cv-sdk-full-l-setupvars__noarch;intel-cv-sdk-full-l-inference-engine__noarch;intel-cv-sdk-full-gfx-install__noarch;intel-cv-sdk-full-shared-pset/g' silent.cfg; fi && \
+    case $(pwd) in \
+        *openvino_toolkit_p_2018*) \
+            COMPONENTS='intel-openvino_base__noarch;intel-dldt_base__noarch;intel-setupvars__noarch;intel-inference_engine_sdk__noarch;intel-inference_engine_rt__noarch;intel-inference_engine_cpu__noarch;intel-inference_engine_vpu__noarch;intel-inference_engine_gna__noarch;intel-inference_engine_dlia__noarch;intel-openvino_base-pset' \
+            ;; \
+        *openvino_toolkit_p_2019*) \
+            COMPONENTS='intel-openvino-base__noarch;intel-openvino-dldt-base__noarch;intel-openvino-setupvars__x86_64;intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-ie-rt__x86_64;intel-openvino-ie-rt-core-ubuntu-xenial__x86_64;intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-vpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-hddl-ubuntu-xenial__x86_64;intel-openvino-gfx-driver__x86_64;intel-openvino-base-pset' \
+            ;; \
+        *openvino_toolkit_fpga_2018*) \
+            COMPONENTS='intel-ism__noarch;intel-cv-sdk-full-shared__noarch;intel-cv-sdk-full-l-setupvars__noarch;intel-cv-sdk-full-l-inference-engine__noarch;intel-cv-sdk-full-gfx-install__noarch;intel-cv-sdk-full-shared-pset' \
+            ;; \
+        *openvino_toolkit_fpga_2019*) \
+            COMPONENTS='intel-openvino-full__noarch;intel-openvino-dldt-full__noarch;intel-openvino-setupvars__x86_64;intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-ie-rt__x86_64;intel-openvino-ie-rt-core-ubuntu-xenial__x86_64;intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-vpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-hddl-ubuntu-xenial__x86_64;intel-openvino-gfx-driver__x86_64;intel-openvino-full-pset' \
+            ;; \
+        *) \
+            COMPONENTS=DEFAULTS \
+            ;; \
+    esac ; \
+    sed -i "s/COMPONENTS=DEFAULTS/COMPONENTS=$COMPONENTS/g" silent.cfg && \
     ./install.sh -s silent.cfg --ignore-signature && \
     rm -Rf $TEMP_DIR $INSTALL_DIR/install_dependencies $INSTALL_DIR/uninstall* /tmp/* $DL_INSTALL_DIR/documentation $DL_INSTALL_DIR/inference_engine/samples
 


### PR DESCRIPTION
In Dockerfile_binary_openvino, the use of pwd piped to grep and checking
grep's result code is here replaced with a simple shell native case
instead. This increases readability and maintainability; should there be
difference between toolkit version it is quite simple to extend the
case. (A bonus is increased performance by using shell natives, even if
that is hardly noticable on a modern computer.)

Fixes #39

Change-Id: I40ad3ac1e98c45e8b197498130412ebe8f03705a
Signed-off-by: Joakim Roubert <joakimr@axis.com>