### PR TITLE
start_server.sh: POSIX compatible, no need for bash

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) 2018 Intel Corporation
 #
@@ -15,5 +15,5 @@
 # limitations under the License.
 #
 cd /ie-serving-py
-source /ie-serving-py/.venv/bin/activate
+. /ie-serving-py/.venv/bin/activate
 exec "$@"


### PR DESCRIPTION
Using '.' instead of 'source' in start_server.sh makes it POSIX
compatible. There is no reason not to have it POSIX compatible.

Fixes #42

Change-Id: I655d391979c5a624b3a79c3409542a1b301c1762
Signed-off-by: Joakim Roubert <joakimr@axis.com>