### PR TITLE
Versions scans wrapped in try-except

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ server it looks like model2 does not have any versions at all.
 Models objects, if initiated correctly, exist on the server and it's 
 `model_paths` are scanned from time to time. If 
 version appears/becomes valid and matches version policy, server will try to load 
-and serve it. If version disappears or get invalid in storage, it gets 
+and serve it. If version disappears or gets invalid in the storage, it gets 
 unloaded in the server.
 
 If model object doesn't get initiated due to accessing `model_path` fail on 
@@ -178,7 +178,7 @@ server start, it
  case of ALL provided models initiations fail, server has nothing to serve 
  and will stop.
  
-If provided model version cannot be loaded it can mean that:
+If detected model version cannot be loaded it can mean that:
 - there is a problem with accessing model files (i. e. due to network issues 
 for remote storage)
 - model files are malformed and inference engine could not get created

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ docker logs ie-serving
 ### Model import issues
 OpenVINO&trade; Model Server loads all defined models versions according 
 to set [version policy](docs/docker_container.md#model-version-policy). 
-Model version is represented by a numerical directory in a model path, 
+A model version is represented by a numerical directory in a model path, 
 containing OpenVINO model files with .bin and .xml extensions.
 
 Below are examples of incorrect structure:
@@ -165,15 +165,15 @@ models/
 In above scenario, server will detect only version `1` of `model1`.
 Directory `2` does not contain valid OpenVINO model files, so it won't 
 be detected as a valid model version. 
-For `model2`, there are correct files, but they are not in numerical directory. 
+For `model2`, there are correct files, but they are not in a numerical directory. 
 The server will not detect any version in `model2`.
 
-When new model version is detected, the server will start loading the model files 
-and start serving new model version. The operation might fail for the following reasons:
+When new model version is detected, the server will loads the model files 
+and starts serving new model version. This operation might fail for the following reasons:
 - there is a problem with accessing model files (i. e. due to network connectivity issues
 to the  remote storage or insufficient permissions)
-- model files are malformed and inference engine could not get created
-- model files require custom CPU extension
+- model files are malformed and can not be imported by the Inference Engine
+- model requires custom CPU extension
 
 In all those situations, the root cause is reported in the server logs or in the response from a call
 to GetModelStatus function. 

--- a/README.md
+++ b/README.md
@@ -141,13 +141,26 @@ docker logs ie-serving
 
 
 ### Model import issues
-OpenVINO&trade; model server will fail to start when any of the defined model cannot be loaded successfully. The root cause of
-the failure can be determined based on the collected logs on the console or in the log file.
+OpenVINO&trade; Model Server will try to load all defined models according 
+to their version policy. 
+Model version is detected when it's a properly named 
+directory in model path, containing OpenVINO model (.bin and .xml files).
+ 
+If provided model cannot be loaded it can mean that:
+- there is a problem with accessing model files (i. e. due to network issues 
+for remote storage)
+- model files are malformed and inference engine could not get created
 
-The following problem might occur during model server initialization and model loading:
-* Missing model files in the location specified in the configuration file.
-* Missing version sub-folders in the model folder.
-* Model files require custom CPU extension.
+In both situations you can get more information in server logs or by 
+requesting model versions statuses. 
+Not loaded version will not be served and will hang in status
+`LOADING` with error message: "Error occurred while loading version".
+When version gets accessible or model files get fixed, server will try to 
+load it on the next update and eventually it's status will change to 
+`AVAILABLE`, which means it's being served. 
+
+On start, server tries to load all defined models. If it can't access any 
+of these models, it provides such information in logs and exits. 
 
 ### Client request issues
 When the model server starts successfully and all the models are imported, there could be a couple of reasons for errors 

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -116,6 +116,9 @@ def parse_one_model(args):
     models = {}
     if model is not None:
         models[args.model_name] = model
+    else:
+        logger.info("Could not access provided models. Server will exit now.")
+        sys.exit()
 
     if args.rest_port > 0:
         process_thread = threading.Thread(target=start_web_rest_server,

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -76,7 +76,8 @@ def parse_config(args):
                                            'base_path'],
                                        batch_size=batch_size,
                                        model_version_policy=model_ver_policy)
-            models[config['config']['name']] = model
+            if model is not None:
+                models[config['config']['name']] = model
         except ValidationError as e_val:
             logger.warning("Model version policy for model {} is invalid. "
                            "Exception: {}".format(config['config']['name'],
@@ -112,7 +113,10 @@ def parse_one_model(args):
         logger.error("Unexpected error occurred. "
                      "Exception: {}".format(e))
         sys.exit()
-    models = {args.model_name: model}
+    models = {}
+    if model is not None:
+        models[args.model_name] = model
+
     if args.rest_port > 0:
         process_thread = threading.Thread(target=start_web_rest_server,
                                           args=[models, args.rest_port])

--- a/ie_serving/main.py
+++ b/ie_serving/main.py
@@ -86,6 +86,10 @@ def parse_config(args):
             logger.warning("Unexpected error occurred in {} model. "
                            "Exception: {}".format(config['config']['name'],
                                                   e))
+    if not models:
+        logger.info("Could not access any of provided models. Server will "
+                    "exit now.")
+        sys.exit()
     if args.rest_port > 0:
         process_thread = threading.Thread(target=start_web_rest_server,
                                           args=[models, args.rest_port])
@@ -117,7 +121,7 @@ def parse_one_model(args):
     if model is not None:
         models[args.model_name] = model
     else:
-        logger.info("Could not access provided models. Server will exit now.")
+        logger.info("Could not access provided model. Server will exit now.")
         sys.exit()
 
     if args.rest_port > 0:

--- a/ie_serving/models/model.py
+++ b/ie_serving/models/model.py
@@ -72,8 +72,6 @@ class Model(ABC):
         versions_attributes = [version for version in versions_attributes
                                if version['version_number']
                                in available_versions]
-        available_versions = [version_attributes['version_number'] for
-                              version_attributes in versions_attributes]
         versions_statuses = dict()
         for version in available_versions:
             versions_statuses[version] = ModelVersionStatus(model_name,
@@ -81,6 +79,9 @@ class Model(ABC):
 
         engines = cls.get_engines_for_model(versions_attributes,
                                             versions_statuses)
+
+        available_versions = [version_attributes['version_number'] for
+                              version_attributes in versions_attributes]
 
         model = cls(model_name=model_name, model_directory=model_directory,
                     available_versions=available_versions, engines=engines,

--- a/ie_serving/models/model.py
+++ b/ie_serving/models/model.py
@@ -62,7 +62,7 @@ class Model(ABC):
         try:
             versions_attributes, available_versions = cls.get_version_metadata(
                 model_directory, batch_size, version_policy_filter)
-        except IOError as error:
+        except Exception as error:
             logger.error("Error occurred while getting versions "
                          "of the model {}".format(model_name))
             logger.error("Failed reading model versions from path: {} "
@@ -96,7 +96,7 @@ class Model(ABC):
                     self.model_directory,
                     self.batch_size,
                     self.version_policy_filter)
-        except IOError as error:
+        except Exception as error:
             logger.error("Error occurred while getting versions "
                          "of the model {}".format(self.model_name))
             logger.error("Failed reading model versions from path: {} "

--- a/ie_serving/models/model.py
+++ b/ie_serving/models/model.py
@@ -58,8 +58,17 @@ class Model(ABC):
         logger.info("Server start loading model: {}".format(model_name))
         version_policy_filter = cls.get_model_version_policy_filter(
             model_version_policy)
-        versions_attributes, available_versions = cls.get_version_metadata(
-            model_directory, batch_size, version_policy_filter)
+
+        try:
+            versions_attributes, available_versions = cls.get_version_metadata(
+                model_directory, batch_size, version_policy_filter)
+        except IOError as error:
+            logger.error("Error occurred while getting versions "
+                         "of the model {}".format(model_name))
+            logger.error("Failed reading model versions from path: {} "
+                         "with error {}".format(model_directory, str(error)))
+            return None
+
         versions_attributes = [version for version in versions_attributes
                                if version['version_number']
                                in available_versions]
@@ -81,10 +90,23 @@ class Model(ABC):
         return model
 
     def update(self):
-        versions_attributes, available_versions = self.get_version_metadata(
-            self.model_directory, self.batch_size, self.version_policy_filter)
+        try:
+            versions_attributes, available_versions = \
+                self.get_version_metadata(
+                    self.model_directory,
+                    self.batch_size,
+                    self.version_policy_filter)
+        except IOError as error:
+            logger.error("Error occurred while getting versions "
+                         "of the model {}".format(self.model_name))
+            logger.error("Failed reading model versions from path: {} "
+                         "with error {}".format(self.model_directory,
+                                                str(error)))
+            return
+
         if available_versions == self.versions:
             return
+
         logger.info("Server start updating model: {}".format(self.model_name))
         to_create, to_delete = self._mark_differences(available_versions)
         logger.debug("Server will try to add {} versions".format(to_create))


### PR DESCRIPTION
Summary of changes:
- Versions scanning code wrapped in try-except. It provides safe handling for issues related with accessing model (i.e. wrong bucket in model path). In that situation server logs error. 
On server start if we fail accessing every provided model, server will exit. 

- Fixed bug with wrong update of available versions list in model building phase