### PR TITLE
fix building docker images in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
             usbutils \
             gnupg2
 
-RUN curl  https://apt.repos.intel.com/openvino/2019/GPG-PUB-KEY-INTEL-OPENVINO-2019 -o GPG-PUB-KEY-INTEL-OPENVINO-2019
-RUN apt-key add GPG-PUB-KEY-INTEL-OPENVINO-2019
+RUN curl -o GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+RUN apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
 RUN echo "deb https://apt.repos.intel.com/openvino/2019/ all main" > /etc/apt/sources.list.d/intel-openvino-2019.list
 
 RUN apt-get update && apt-get install -y intel-openvino-dev-ubuntu18-2019.2.242

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl -o GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
 RUN apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
-RUN echo "deb https://apt.repos.intel.com/openvino/2019/ all main" > /etc/apt/sources.list.d/intel-openvino-2019.list
+RUN echo "deb [trusted=yes] https://apt.repos.intel.com/openvino/2019/ all main" > /etc/apt/sources.list.d/intel-openvino-2019.list
 
 RUN apt-get update && apt-get install -y intel-openvino-dev-ubuntu18-2019.2.242
 

--- a/Dockerfile_clearlinux
+++ b/Dockerfile_clearlinux
@@ -1,6 +1,6 @@
 FROM clearlinux
 
-RUN swupd update -V 31070 && swupd bundle-add computer-vision-basic && swupd clean
+RUN swupd update && swupd bundle-add computer-vision-basic && swupd clean
 # OpenVino R2 version
 
 COPY start_server.sh setup.py requirements_clearlinux.txt version /ie-serving-py/


### PR DESCRIPTION
clearlinux version can't be easily downgraded so the latest package will be used.
signing key for apt packages expired so temporarily gpg key check is skipped