### PR TITLE
Support binary build with OpenVino 2020.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .venv
 .vs
+.vscode
 *~
 *.pyc
 *.pyo

--- a/Dockerfile_binary_openvino
+++ b/Dockerfile_binary_openvino
@@ -33,7 +33,7 @@ RUN mkdir -p $TEMP_DIR && cd $TEMP_DIR/ && \
         *openvino_toolkit_fpga_2019.2) \
             COMPONENTS='intel-openvino-full__noarch;intel-openvino-dldt-full__noarch;intel-openvino-setupvars__x86_64;intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-ie-rt__x86_64;intel-openvino-ie-rt-core-ubuntu-xenial__x86_64;intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-vpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-hddl-ubuntu-xenial__x86_64;intel-openvino-gfx-driver__x86_64;intel-openvino-full-pset' \
             ;; \
-        *openvino_toolkit_p_2019.3* | *openvino_toolkit_p_2020.1*) \
+        *openvino_toolkit_p_2019.3* | *openvino_toolkit_p_2020.1* | *openvino_toolkit_p_2020.2*) \
             COMPONENTS='intel-openvino-base__noarch;intel-openvino-dldt-base__noarch;intel-openvino-setupvars__noarch;intel-openvino-eula__noarch;intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-ie-bin-python-tools-ubuntu-xenial__x86_64;intel-openvino-ie-samples__x86_64;intel-openvino-ie-rt__x86_64;intel-openvino-ie-bin-3rd-debug__x86_64;intel-openvino-ie-rt-core-ubuntu-xenial__x86_64;intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-gpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-vpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-gna-ubuntu-xenial__x86_64;intel-openvino-ie-rt-hddl-ubuntu-xenial__x86_64;intel-openvino-omz-tools__x86_64;intel-openvino-docs__noarch;intel-openvino-gfx-driver-ubuntu-xenial__x86_64;intel-openvino-base-pset' \
             ;; \
         *openvino_toolkit_fpga_2019.3*) \

--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ docker_build_bin:
 	@echo OpenVINO Model Server version: $(OVMS_VERSION) > version
 	@echo Git commit: `git rev-parse HEAD` >> version
 	@echo OpenVINO version: `ls -1 l_openvino_toolkit*` >> version
-	@echo docker build -f Dockerfile_binary_openvino --build-arg http_proxy=$(HTTP_PROXY) --build-arg https_proxy="$(HTTPS_PROXY)" --build-arg DLDT_PACKAGE_URL="$(DLDT_PACKAGE_URL)" -t $(DOCKER_OVMS_TAG) .
-	@docker build -f Dockerfile_binary_openvino --build-arg http_proxy=$(HTTP_PROXY) --build-arg https_proxy="$(HTTPS_PROXY)" --build-arg DLDT_PACKAGE_URL="$(DLDT_PACKAGE_URL)" -t $(DOCKER_OVMS_TAG) .
+	@echo docker build -f Dockerfile_binary_openvino --build-arg no_proxy=$(no_proxy) --build-arg http_proxy=$(HTTP_PROXY) --build-arg https_proxy="$(HTTPS_PROXY)" --build-arg DLDT_PACKAGE_URL="$(DLDT_PACKAGE_URL)" -t $(DOCKER_OVMS_TAG) .
+	@docker build -f Dockerfile_binary_openvino --build-arg no_proxy=$(no_proxy) --build-arg http_proxy=$(HTTP_PROXY) --build-arg https_proxy="$(HTTPS_PROXY)" --build-arg DLDT_PACKAGE_URL="$(DLDT_PACKAGE_URL)" -t $(DOCKER_OVMS_TAG) .
 
 docker_build_clearlinux:
 	@echo "Building docker image"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ie_serving',
-    version="2020.1",
+    version="2020.2",
     description="DLDT inference server",
     long_description="""DLDT inference server""",
     keywords='',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ie_serving',
-    version="2020.2",
+    version="2020.1",
     description="DLDT inference server",
     long_description="""DLDT inference server""",
     keywords='',

--- a/tests/scripts/functional-tests-bin.sh
+++ b/tests/scripts/functional-tests-bin.sh
@@ -6,7 +6,7 @@ DOCKER_OVMS_TAG="ie-serving-bin:latest"
 export TESTS_SUFFIX="bin"
 export PORTS_PREFIX="92 57"
 
-make DOCKER_OVMS_TAG=${DOCKER_OVMS_TAG} docker_build_bin dldt_package_url=${OPENVINO_DOWNLOAD_LINK_2020_1}
+make DOCKER_OVMS_TAG=${DOCKER_OVMS_TAG} docker_build_bin dldt_package_url=${OPENVINO_DOWNLOAD_LINK_2020_2}
 
 . .venv-jenkins/bin/activate
 


### PR DESCRIPTION
* Added a small change that allows to build `Dockerfile_binary_openvino` with OpenVino 2020.2
* `no_proxy` will be propagated correctly in `make docker_build_bin`
* Added `.vscode` to .gitignore